### PR TITLE
MD-3114: Unit tests fail with AssertionError: Conversion to relational algebra failed to preserve datatypes

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -41,7 +41,10 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -312,6 +315,14 @@ public class SqlConverter {
         new SqlToRelConverter(new Expander(), validator, catalog, cluster, DrillConvertletTable.INSTANCE,
             sqlToRelConverterConfig);
     //Changes to support Calcite 1.13.
+
+    /*
+     * Sets value to false to avoid simplifying project expressions
+     * during creating new projects since it may cause changing data mode
+     * which causes to assertion errors during type validation
+     */
+    Hook.REL_BUILDER_SIMPLIFY.add(Hook.property(false));
+
     final RelRoot rel = sqlToRelConverter.convertQuery(validatedNode, false, false);
     final RelRoot rel2 = rel.withRel(sqlToRelConverter.flattenTypes(rel.rel, true));
     final RelRoot rel3 = rel2.withRel(RelDecorrelator.decorrelateQuery(rel2.rel));
@@ -511,6 +522,28 @@ public class SqlConverter {
         RexNode node,
         boolean matchNullability) {
       return node;
+    }
+
+    /**
+     * Creates a call to the CAST operator, expanding if possible, and optionally
+     * also preserving nullability.
+     *
+     * <p>Tries to expand the cast, and therefore the result may be something
+     * other than a {@link RexCall} to the CAST operator, such as a
+     * {@link RexLiteral} if {@code matchNullability} is false.
+     *
+     * @param type             Type to cast to
+     * @param exp              Expression being cast
+     * @param matchNullability Whether to ensure the result has the same
+     *                         nullability as {@code type}
+     * @return Call to CAST operator
+     */
+    @Override
+    public RexNode makeCast(RelDataType type, RexNode exp, boolean matchNullability) {
+      if (matchNullability) {
+        return makeAbstractCast(type, exp);
+      }
+      return super.makeCast(type, exp, false);
     }
   }
 


### PR DESCRIPTION
Fixed TestCaseNullableTypes.testCaseNullableTypesVarchar, TestCastEmptyStrings.testCastInputTypeNonNullableVarCharToDecimal and TestCastEmptyStrings.testCastInputTypeNonNullableVarCharToNumeric tests