### PR TITLE
DRILL-3993: Changes to support Calcite 1.15.

### DIFF
--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSchemaFactory.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSchemaFactory.java
@@ -72,7 +72,14 @@ public class HBaseSchemaFactory implements SchemaFactory {
     @Override
     public Table getTable(String name) {
       HBaseScanSpec scanSpec = new HBaseScanSpec(name);
-      return new DrillHBaseTable(schemaName, plugin, scanSpec);
+      try {
+        return new DrillHBaseTable(schemaName, plugin, scanSpec);
+      } catch (Exception e) {
+        // Calcite firstly looks table in the default schema, if no table was found, it looks in root schema.
+        // If table does not exists, query will fail at validation stage, so error should not be thrown there.
+        logger.warn("Failure while loading table '{}' for database '{}'.", name, schemaName, e.getCause());
+        return null;
+      }
     }
 
     @Override

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveDatabaseSchema.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveDatabaseSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,14 +17,16 @@
  */
 package org.apache.drill.exec.store.hive.schema;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.SchemaConfig;
@@ -37,15 +39,15 @@ import java.util.List;
 import java.util.Set;
 
 public class HiveDatabaseSchema extends AbstractSchema{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HiveDatabaseSchema.class);
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HiveDatabaseSchema.class);
 
   private final HiveSchema hiveSchema;
   private Set<String> tables;
   private final DrillHiveMetaStoreClient mClient;
   private final SchemaConfig schemaConfig;
 
-  public HiveDatabaseSchema( //
-      HiveSchema hiveSchema, //
+  public HiveDatabaseSchema(
+      HiveSchema hiveSchema,
       String name,
       DrillHiveMetaStoreClient mClient,
       SchemaConfig schemaConfig) {
@@ -125,6 +127,17 @@ public class HiveDatabaseSchema extends AbstractSchema{
     @Override
     public Schema.TableType getJdbcTableType() {
       return tableType;
+    }
+
+    @Override
+    public boolean rolledUpColumnValidInsideAgg(String column,
+        SqlCall call, SqlNode parent, CalciteConnectionConfig config) {
+      return true;
+    }
+
+    @Override
+    public boolean isRolledUp(String column) {
+      return false;
     }
   }
 

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/schema/OpenTSDBSchemaFactory.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/schema/OpenTSDBSchemaFactory.java
@@ -61,7 +61,14 @@ public class OpenTSDBSchemaFactory implements SchemaFactory {
     @Override
     public Table getTable(String name) {
       OpenTSDBScanSpec scanSpec = new OpenTSDBScanSpec(name);
+      try {
         return new DrillOpenTSDBTable(schemaName, plugin, new Schema(plugin.getClient(), name), scanSpec);
+      } catch (Exception e) {
+        // Calcite firstly looks table in the default schema, if no table was found, it looks in root schema.
+        // If table does not exists, query will fail at validation stage, so error should not be thrown there.
+        logger.warn("Failure while loading table '{}' for database '{}'.", name, schemaName, e.getCause());
+        return null;
+      }
     }
 
     @Override

--- a/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
+++ b/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
@@ -154,19 +154,19 @@ SqlNodeList ParseOptionalFieldList(String relType) :
 /** Parses a required field list and makes sure no field is a "*". */
 SqlNodeList ParseRequiredFieldList(String relType) :
 {
-    SqlNodeList fieldList;
+    Pair<SqlNodeList, SqlNodeList> fieldList;
 }
 {
     <LPAREN>
     fieldList = ParenthesizedCompoundIdentifierList()
     <RPAREN>
     {
-        for(SqlNode node : fieldList)
+        for(SqlNode node : fieldList.left)
         {
-            if (((SqlIdentifier)node).isStar())
+            if (((SqlIdentifier) node).isStar())
                 throw new ParseException(String.format("%s's field list has a '*', which is invalid.", relType));
         }
-        return fieldList;
+        return fieldList.left;
     }
 }
 
@@ -357,7 +357,7 @@ SqlNode SqlDropFunction() :
 /**
 * Parses a comma-separated list of simple identifiers.
 */
-SqlNodeList ParenthesizedCompoundIdentifierList() :
+Pair<SqlNodeList, SqlNodeList> ParenthesizedCompoundIdentifierList() :
 {
     List<SqlIdentifier> list = new ArrayList<SqlIdentifier>();
     SqlIdentifier id;
@@ -367,7 +367,7 @@ SqlNodeList ParenthesizedCompoundIdentifierList() :
     (
    <COMMA> id = SimpleIdentifier() {list.add(id);}) *
     {
-       return new SqlNodeList(list, getPos());
+       return Pair.of(new SqlNodeList(list, getPos()), null);
     }
 }
 </#if>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillReduceAggregatesRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillReduceAggregatesRule.java
@@ -32,12 +32,14 @@ import org.apache.calcite.rel.InvalidRelException;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.fun.SqlCountAggFunction;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.trace.CalciteTrace;
+import org.apache.drill.exec.expr.fn.DrillFuncHolder;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.planner.sql.DrillCalciteSqlAggFunctionWrapper;
 import org.apache.drill.exec.planner.sql.DrillSqlOperator;
@@ -234,7 +236,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
       return reduceSum(oldAggRel, oldCall, newCalls, aggCallMapping);
     }
     if (sqlAggFunction instanceof SqlAvgAggFunction) {
-      final SqlAvgAggFunction.Subtype subtype = ((SqlAvgAggFunction) sqlAggFunction).getSubtype();
+      final SqlKind subtype = sqlAggFunction.getKind();
       switch (subtype) {
       case AVG:
         // replace original AVG(x) with SUM(x) / COUNT(x)
@@ -314,14 +316,21 @@ public class DrillReduceAggregatesRule extends RelOptRule {
             oldAggRel.getInput(),
             iAvgInput);
     RelDataType sumType =
+        TypeInferenceUtils.getDrillSqlReturnTypeInference(SqlKind.SUM.name(),
+            ImmutableList.<DrillFuncHolder>of())
+          .inferReturnType(oldCall.createBinding(oldAggRel));
+    sumType =
         typeFactory.createTypeWithNullability(
-            avgInputType,
-            avgInputType.isNullable() || nGroups == 0);
-    SqlAggFunction sumAgg = new SqlSumEmptyIsZeroAggFunction();
-    AggregateCall sumCall = AggregateCall.create(sumAgg, oldCall.isDistinct(), oldCall.getArgList(), -1, sumType, null);
+            sumType,
+            sumType.isNullable() || nGroups == 0);
+    SqlAggFunction sumAgg =
+        new DrillCalciteSqlAggFunctionWrapper(new SqlSumEmptyIsZeroAggFunction(), sumType);
+    AggregateCall sumCall = AggregateCall.create(sumAgg, oldCall.isDistinct(),
+        oldCall.isApproximate(), oldCall.getArgList(), -1, sumType, null);
     final SqlCountAggFunction countAgg = (SqlCountAggFunction) SqlStdOperatorTable.COUNT;
     final RelDataType countType = countAgg.getReturnType(typeFactory);
-    AggregateCall countCall = AggregateCall.create(countAgg, oldCall.isDistinct(), oldCall.getArgList(), -1, countType, null);
+    AggregateCall countCall = AggregateCall.create(countAgg, oldCall.isDistinct(),
+        oldCall.isApproximate(), oldCall.getArgList(), -1, countType, null);
 
     RexNode tmpsumRef =
         rexBuilder.addAggCall(
@@ -370,7 +379,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
             newCalls,
             aggCallMapping,
             ImmutableList.of(avgInputType));
-    if(isInferenceEnabled) {
+    if (isInferenceEnabled) {
       return rexBuilder.makeCall(
           new DrillSqlOperator(
               "divide",
@@ -408,20 +417,21 @@ public class DrillReduceAggregatesRule extends RelOptRule {
             arg);
     final RelDataType sumType;
     final SqlAggFunction sumZeroAgg;
-    if(isInferenceEnabled) {
+    if (isInferenceEnabled) {
       sumType = oldCall.getType();
-      sumZeroAgg = new DrillCalciteSqlAggFunctionWrapper(
-          new SqlSumEmptyIsZeroAggFunction(), sumType);
     } else {
       sumType =
           typeFactory.createTypeWithNullability(
-              argType, argType.isNullable());
-      sumZeroAgg = new SqlSumEmptyIsZeroAggFunction();
+              oldCall.getType(), argType.isNullable());
     }
-    AggregateCall sumZeroCall =AggregateCall.create(sumZeroAgg, oldCall.isDistinct(), oldCall.getArgList(), -1, sumType, null);
+    sumZeroAgg = new DrillCalciteSqlAggFunctionWrapper(
+        new SqlSumEmptyIsZeroAggFunction(), sumType);
+    AggregateCall sumZeroCall = AggregateCall.create(sumZeroAgg, oldCall.isDistinct(),
+        oldCall.isApproximate(), oldCall.getArgList(), -1, sumType, null);
     final SqlCountAggFunction countAgg = (SqlCountAggFunction) SqlStdOperatorTable.COUNT;
     final RelDataType countType = countAgg.getReturnType(typeFactory);
-    AggregateCall countCall = AggregateCall.create(countAgg, oldCall.isDistinct(), oldCall.getArgList(), -1, countType, null);
+    AggregateCall countCall = AggregateCall.create(countAgg, oldCall.isDistinct(),
+        oldCall.isApproximate(), oldCall.getArgList(), -1, countType, null);
     // NOTE:  these references are with respect to the output
     // of newAggRel
     RexNode sumZeroRef =
@@ -495,14 +505,17 @@ public class DrillReduceAggregatesRule extends RelOptRule {
             SqlStdOperatorTable.MULTIPLY, argRef, argRef);
     final int argSquaredOrdinal = lookupOrAdd(inputExprs, argSquared);
 
-    final RelDataType sumType =
-        typeFactory.createTypeWithNullability(
-            argType,
-            true);
+    RelDataType sumType =
+        TypeInferenceUtils.getDrillSqlReturnTypeInference(SqlKind.SUM.name(),
+            ImmutableList.<DrillFuncHolder>of())
+          .inferReturnType(oldCall.createBinding(oldAggRel));
+    sumType = typeFactory.createTypeWithNullability(sumType, true);
     final AggregateCall sumArgSquaredAggCall =
         AggregateCall.create(
-            new SqlSumAggFunction(sumType),
+            new DrillCalciteSqlAggFunctionWrapper(
+                new SqlSumAggFunction(sumType), sumType),
             oldCall.isDistinct(),
+            oldCall.isApproximate(),
             ImmutableIntList.of(argSquaredOrdinal),
             -1,
             sumType,
@@ -518,8 +531,10 @@ public class DrillReduceAggregatesRule extends RelOptRule {
 
     final AggregateCall sumArgAggCall =
         AggregateCall.create(
-            new SqlSumAggFunction(sumType),
+            new DrillCalciteSqlAggFunctionWrapper(
+                new SqlSumAggFunction(sumType), sumType),
             oldCall.isDistinct(),
+            oldCall.isApproximate(),
             ImmutableIntList.of(argOrdinal),
             -1,
             sumType,
@@ -539,7 +554,8 @@ public class DrillReduceAggregatesRule extends RelOptRule {
 
     final SqlCountAggFunction countAgg = (SqlCountAggFunction) SqlStdOperatorTable.COUNT;
     final RelDataType countType = countAgg.getReturnType(typeFactory);
-    final AggregateCall countArgAggCall = AggregateCall.create(countAgg, oldCall.isDistinct(), oldCall.getArgList(), -1, countType, null);
+    final AggregateCall countArgAggCall = AggregateCall.create(countAgg, oldCall.isDistinct(),
+        oldCall.isApproximate(), oldCall.getArgList(), -1, countType, null);
     final RexNode countArg =
         rexBuilder.addAggCall(
             countArgAggCall,
@@ -566,7 +582,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
       final RexLiteral one =
           rexBuilder.makeExactLiteral(BigDecimal.ONE);
       final RexNode nul =
-          rexBuilder.makeNullLiteral(countArg.getType().getSqlTypeName());
+          rexBuilder.makeNullLiteral(countArg.getType());
       final RexNode countMinusOne =
           rexBuilder.makeCall(
               SqlStdOperatorTable.MINUS, countArg, one);
@@ -580,7 +596,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
     }
 
     final SqlOperator divide;
-    if(isInferenceEnabled) {
+    if (isInferenceEnabled) {
       divide = new DrillSqlOperator(
           "divide",
           2,
@@ -603,7 +619,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
               SqlStdOperatorTable.POWER, div, half);
     }
 
-    if(isInferenceEnabled) {
+    if (isInferenceEnabled) {
       return result;
     } else {
      /*
@@ -670,7 +686,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
     public boolean matches(RelOptRuleCall call) {
       DrillAggregateRel oldAggRel = (DrillAggregateRel) call.rels[0];
       for (AggregateCall aggregateCall : oldAggRel.getAggCallList()) {
-        if(isConversionToSumZeroNeeded(aggregateCall.getAggregation(), aggregateCall.getType())) {
+        if (isConversionToSumZeroNeeded(aggregateCall.getAggregation(), aggregateCall.getType())) {
           return true;
         }
       }
@@ -684,7 +700,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
       final Map<AggregateCall, RexNode> aggCallMapping = Maps.newHashMap();
       final List<AggregateCall> newAggregateCalls = Lists.newArrayList();
       for (AggregateCall oldAggregateCall : oldAggRel.getAggCallList()) {
-        if(isConversionToSumZeroNeeded(oldAggregateCall.getAggregation(), oldAggregateCall.getType())) {
+        if (isConversionToSumZeroNeeded(oldAggregateCall.getAggregation(), oldAggregateCall.getType())) {
           final RelDataType argType = oldAggregateCall.getType();
           final RelDataType sumType = oldAggRel.getCluster().getTypeFactory()
               .createTypeWithNullability(argType, argType.isNullable());
@@ -694,6 +710,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
               AggregateCall.create(
                   sumZeroAgg,
                   oldAggregateCall.isDistinct(),
+                  oldAggregateCall.isApproximate(),
                   oldAggregateCall.getArgList(),
                   -1,
                   sumType,
@@ -733,9 +750,9 @@ public class DrillReduceAggregatesRule extends RelOptRule {
     @Override
     public boolean matches(RelOptRuleCall call) {
       final DrillWindowRel oldWinRel = (DrillWindowRel) call.rels[0];
-      for(Window.Group group : oldWinRel.groups) {
-        for(Window.RexWinAggCall rexWinAggCall : group.aggCalls) {
-          if(isConversionToSumZeroNeeded(rexWinAggCall.getOperator(), rexWinAggCall.getType())) {
+      for (Window.Group group : oldWinRel.groups) {
+        for (Window.RexWinAggCall rexWinAggCall : group.aggCalls) {
+          if (isConversionToSumZeroNeeded(rexWinAggCall.getOperator(), rexWinAggCall.getType())) {
             return true;
           }
         }
@@ -748,10 +765,10 @@ public class DrillReduceAggregatesRule extends RelOptRule {
       final DrillWindowRel oldWinRel = (DrillWindowRel) call.rels[0];
       final ImmutableList.Builder<Window.Group> builder = ImmutableList.builder();
 
-      for(Window.Group group : oldWinRel.groups) {
+      for (Window.Group group : oldWinRel.groups) {
         final List<Window.RexWinAggCall> aggCalls = Lists.newArrayList();
-        for(Window.RexWinAggCall rexWinAggCall : group.aggCalls) {
-          if(isConversionToSumZeroNeeded(rexWinAggCall.getOperator(), rexWinAggCall.getType())) {
+        for (Window.RexWinAggCall rexWinAggCall : group.aggCalls) {
+          if (isConversionToSumZeroNeeded(rexWinAggCall.getOperator(), rexWinAggCall.getType())) {
             final RelDataType argType = rexWinAggCall.getType();
             final RelDataType sumType = oldWinRel.getCluster().getTypeFactory()
                 .createTypeWithNullability(argType, argType.isNullable());
@@ -792,7 +809,7 @@ public class DrillReduceAggregatesRule extends RelOptRule {
 
   private static boolean isConversionToSumZeroNeeded(SqlOperator sqlOperator, RelDataType type) {
     sqlOperator = DrillCalciteWrapperUtility.extractSqlOperatorFromWrapper(sqlOperator);
-    if(sqlOperator instanceof SqlSumAggFunction
+    if (sqlOperator instanceof SqlSumAggFunction
         && !type.isNullable()) {
       // If SUM(x) is not nullable, the validator must have determined that
       // nulls are impossible (because the group is never empty and x is never

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,12 +19,15 @@ package org.apache.drill.exec.planner.logical;
 
 import java.io.IOException;
 
+import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.GroupScan;
@@ -121,6 +124,16 @@ public abstract class DrillTable implements Table {
   @Override
   public TableType getJdbcTableType() {
     return tableType;
+  }
+
+  @Override
+  public boolean rolledUpColumnValidInsideAgg(String column,
+      SqlCall call, SqlNode parent, CalciteConnectionConfig config) {
+    return true;
+  }
+
+  @Override public boolean isRolledUp(String column) {
+    return false;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTranslatableTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTranslatableTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner.logical;
 
+import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptTable.ToRelContext;
 import org.apache.calcite.rel.RelNode;
@@ -25,7 +26,8 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.Schema.TableType;
-import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
 
 /**
  * TableMacros must return a TranslatableTable
@@ -62,6 +64,17 @@ public class DrillTranslatableTable implements TranslatableTable {
   @Override
   public TableType getJdbcTableType() {
     return drillTable.getJdbcTableType();
+  }
+
+  @Override
+  public boolean rolledUpColumnValidInsideAgg(String column,
+      SqlCall call, SqlNode parent, CalciteConnectionConfig config) {
+    return true;
+  }
+
+  @Override
+  public boolean isRolledUp(String column) {
+    return false;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillViewTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillViewTable.java
@@ -17,11 +17,14 @@
  */
 package org.apache.drill.exec.planner.logical;
 
+import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.schema.TranslatableTable;
 
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.drill.exec.dotdrill.View;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.plan.RelOptTable;
@@ -89,5 +92,15 @@ public class DrillViewTable implements TranslatableTable, DrillViewInfoProvider 
   @Override
   public String getViewSql() {
     return view.getSql();
+  }
+
+  @Override
+  public boolean rolledUpColumnValidInsideAgg(String column,
+      SqlCall call, SqlNode parent, CalciteConnectionConfig config) {
+    return true;
+  }
+
+  @Override public boolean isRolledUp(String column) {
+    return false;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +20,7 @@ package org.apache.drill.exec.planner.physical;
 
 import java.util.List;
 
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.BitSets;
 
 import org.apache.drill.exec.planner.logical.DrillAggregateRel;
@@ -71,8 +72,11 @@ public abstract class AggPruleBase extends Prule {
 
     for (AggregateCall aggCall : aggregate.getAggCallList()) {
       String name = aggCall.getAggregation().getName();
-      if ( ! (name.equals("SUM") || name.equals("MIN") || name.equals("MAX") || name.equals("COUNT")
-              || name.equals("$SUM0"))) {
+      if (!(name.equals(SqlKind.SUM.name())
+          || name.equals(SqlKind.MIN.name())
+          || name.equals(SqlKind.MAX.name())
+          || name.equals(SqlKind.COUNT.name())
+          || name.equals("$SUM0"))) {
         return false;
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillAvgVarianceConvertlet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillAvgVarianceConvertlet.java
@@ -20,11 +20,11 @@ package org.apache.drill.exec.planner.sql;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.SqlOperatorBinding;
-import org.apache.calcite.sql.fun.SqlAvgAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
@@ -42,7 +42,7 @@ import org.apache.calcite.util.Util;
  */
 public class DrillAvgVarianceConvertlet implements SqlRexConvertlet {
 
-  private final SqlAvgAggFunction.Subtype subtype;
+  private final SqlKind subtype;
   private static final DrillSqlOperator CastHighOp = new DrillSqlOperator("CastHigh", 1, false,
       new SqlReturnTypeInference() {
         @Override
@@ -54,7 +54,7 @@ public class DrillAvgVarianceConvertlet implements SqlRexConvertlet {
         }
       }, false);
 
-  public DrillAvgVarianceConvertlet(SqlAvgAggFunction.Subtype subtype) {
+  public DrillAvgVarianceConvertlet(SqlKind subtype) {
     this.subtype = subtype;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillConvertletTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillConvertletTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,8 +21,8 @@ import java.util.HashMap;
 
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.fun.SqlAvgAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql2rel.SqlRexConvertlet;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
@@ -38,11 +38,13 @@ public class DrillConvertletTable implements SqlRexConvertletTable{
   static {
     // Use custom convertlet for extract function
     map.put(SqlStdOperatorTable.EXTRACT, DrillExtractConvertlet.INSTANCE);
-    map.put(SqlStdOperatorTable.AVG, new DrillAvgVarianceConvertlet(SqlAvgAggFunction.Subtype.AVG));
-    map.put(SqlStdOperatorTable.STDDEV_POP, new DrillAvgVarianceConvertlet(SqlAvgAggFunction.Subtype.STDDEV_POP));
-    map.put(SqlStdOperatorTable.STDDEV_SAMP, new DrillAvgVarianceConvertlet(SqlAvgAggFunction.Subtype.STDDEV_SAMP));
-    map.put(SqlStdOperatorTable.VAR_POP, new DrillAvgVarianceConvertlet(SqlAvgAggFunction.Subtype.VAR_POP));
-    map.put(SqlStdOperatorTable.VAR_SAMP, new DrillAvgVarianceConvertlet(SqlAvgAggFunction.Subtype.VAR_SAMP));
+    map.put(SqlStdOperatorTable.AVG, new DrillAvgVarianceConvertlet(SqlKind.AVG));
+    map.put(SqlStdOperatorTable.STDDEV_POP, new DrillAvgVarianceConvertlet(SqlKind.STDDEV_POP));
+    map.put(SqlStdOperatorTable.STDDEV_SAMP, new DrillAvgVarianceConvertlet(SqlKind.STDDEV_SAMP));
+    map.put(SqlStdOperatorTable.STDDEV, new DrillAvgVarianceConvertlet(SqlKind.STDDEV_SAMP));
+    map.put(SqlStdOperatorTable.VAR_POP, new DrillAvgVarianceConvertlet(SqlKind.VAR_POP));
+    map.put(SqlStdOperatorTable.VAR_SAMP, new DrillAvgVarianceConvertlet(SqlKind.VAR_SAMP));
+    map.put(SqlStdOperatorTable.VARIANCE, new DrillAvgVarianceConvertlet(SqlKind.VAR_SAMP));
   }
 
   /*

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.sql;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import com.google.common.base.Strings;
@@ -26,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.ConventionTraitDef;
@@ -537,7 +540,8 @@ public class SqlConverter {
                               JavaTypeFactory typeFactory,
                               DrillConfig drillConfig,
                               UserSession session) {
-      super(CalciteSchema.from(rootSchema), caseSensitive, defaultSchema, typeFactory);
+      super(CalciteSchema.from(rootSchema), defaultSchema,
+          typeFactory, getConnectionConfig(caseSensitive));
       this.drillConfig = drillConfig;
       this.session = session;
       this.allowTemporaryTables = true;
@@ -649,5 +653,18 @@ public class SqlConverter {
           SchemaUtilites.isTemporaryWorkspace(
               SchemaUtilites.SCHEMA_PATH_JOINER.join(defaultSchemaPath, schemaPath), drillConfig);
     }
+  }
+
+  /**
+   * Creates {@link CalciteConnectionConfigImpl} instance with specified caseSensitive property.
+   *
+   * @param caseSensitive is case sensitive.
+   * @return {@link CalciteConnectionConfigImpl} instance
+   */
+  private static CalciteConnectionConfigImpl getConnectionConfig(boolean caseSensitive) {
+    Properties properties = new Properties();
+    properties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(),
+        String.valueOf(caseSensitive));
+    return new CalciteConnectionConfigImpl(properties);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
@@ -32,7 +32,6 @@ import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.SqlOperatorBinding;
-import org.apache.calcite.sql.fun.SqlAvgAggFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
@@ -134,21 +133,21 @@ public class TypeInferenceUtils {
 
   private static final ImmutableMap<String, SqlReturnTypeInference> funcNameToInference = ImmutableMap.<String, SqlReturnTypeInference> builder()
       .put("DATE_PART", DrillDatePartSqlReturnTypeInference.INSTANCE)
-      .put("SUM", DrillSumSqlReturnTypeInference.INSTANCE)
-      .put("COUNT", DrillCountSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.SUM.name(), DrillSumSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.COUNT.name(), DrillCountSqlReturnTypeInference.INSTANCE)
       .put("CONCAT", DrillConcatSqlReturnTypeInference.INSTANCE_CONCAT)
       .put("CONCATOPERATOR", DrillConcatSqlReturnTypeInference.INSTANCE_CONCAT_OP)
       .put("LENGTH", DrillLengthSqlReturnTypeInference.INSTANCE)
       .put("LPAD", DrillPadSqlReturnTypeInference.INSTANCE)
       .put("RPAD", DrillPadSqlReturnTypeInference.INSTANCE)
-      .put("LTRIM", DrillTrimSqlReturnTypeInference.INSTANCE)
-      .put("RTRIM", DrillTrimSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.LTRIM.name(), DrillTrimSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.RTRIM.name(), DrillTrimSqlReturnTypeInference.INSTANCE)
       .put("BTRIM", DrillTrimSqlReturnTypeInference.INSTANCE)
-      .put("TRIM", DrillTrimSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.TRIM.name(), DrillTrimSqlReturnTypeInference.INSTANCE)
       .put("CONVERT_TO", DrillConvertToSqlReturnTypeInference.INSTANCE)
-      .put("EXTRACT", DrillExtractSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.EXTRACT.name(), DrillExtractSqlReturnTypeInference.INSTANCE)
       .put("SQRT", DrillSqrtSqlReturnTypeInference.INSTANCE)
-      .put("CAST", DrillCastSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.CAST.name(), DrillCastSqlReturnTypeInference.INSTANCE)
       .put("FLATTEN", DrillDeferToExecSqlReturnTypeInference.INSTANCE)
       .put("KVGEN", DrillDeferToExecSqlReturnTypeInference.INSTANCE)
       .put("CONVERT_FROM", DrillDeferToExecSqlReturnTypeInference.INSTANCE)
@@ -168,22 +167,22 @@ public class TypeInferenceUtils {
       .put(SqlKind.ROW_NUMBER.name(), DrillRankingSqlReturnTypeInference.INSTANCE_BIGINT)
 
       // NTILE
-      .put("NTILE", DrillNTILESqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.NTILE.name(), DrillNTILESqlReturnTypeInference.INSTANCE)
 
       // LEAD, LAG
-      .put("LEAD", DrillLeadLagSqlReturnTypeInference.INSTANCE)
-      .put("LAG", DrillLeadLagSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.LEAD.name(), DrillLeadLagSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.LAG.name(), DrillLeadLagSqlReturnTypeInference.INSTANCE)
 
       // FIRST_VALUE, LAST_VALUE
-      .put("FIRST_VALUE", DrillSameSqlReturnTypeInference.INSTANCE)
-      .put("LAST_VALUE", DrillSameSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.FIRST_VALUE.name(), DrillSameSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.LAST_VALUE.name(), DrillSameSqlReturnTypeInference.INSTANCE)
 
       // Functions rely on DrillReduceAggregatesRule for expression simplification as opposed to getting evaluated directly
-      .put(SqlAvgAggFunction.Subtype.AVG.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
-      .put(SqlAvgAggFunction.Subtype.STDDEV_POP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
-      .put(SqlAvgAggFunction.Subtype.STDDEV_SAMP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
-      .put(SqlAvgAggFunction.Subtype.VAR_POP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
-      .put(SqlAvgAggFunction.Subtype.VAR_SAMP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.AVG.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.STDDEV_POP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.STDDEV_SAMP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.VAR_POP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
+      .put(SqlKind.VAR_SAMP.name(), DrillAvgAggSqlReturnTypeInference.INSTANCE)
       .build();
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.Function;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Table;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.common.exceptions.UserException;
@@ -197,17 +198,12 @@ public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer,
   }
 
   @Override
-  public boolean contentsHaveChangedSince(long lastCheck, long now) {
-    return true;
-  }
-
-  @Override
   public void close() throws Exception {
     // no-op: default implementation for most implementations.
   }
 
   @Override
-  public Schema snapshot(long now) {
+  public Schema snapshot(SchemaVersion version) {
     return this;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorageEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorageEngine.java
@@ -22,7 +22,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,6 +116,7 @@ public class MockStorageEngine extends AbstractStoragePlugin {
   private static class MockSchema extends AbstractSchema {
 
     private MockStorageEngine engine;
+    private final Map<String, Table> tableCache = new WeakHashMap<>();
 
     public MockSchema(MockStorageEngine engine) {
       super(ImmutableList.<String>of(), MockStorageEngineConfig.NAME);
@@ -122,11 +125,16 @@ public class MockStorageEngine extends AbstractStoragePlugin {
 
     @Override
     public Table getTable(String name) {
-      if (name.toLowerCase().endsWith(".json")) {
-        return getConfigFile(name);
-      } else {
-        return getDirectTable(name);
+      Table table = tableCache.get(name);
+      if (table == null) {
+        if (name.toLowerCase().endsWith(".json")) {
+          table = getConfigFile(name);
+        } else {
+          table = getDirectTable(name);
+        }
+        tableCache.put(name, table);
       }
+      return table;
     }
 
     private Table getConfigFile(String name) {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
@@ -198,7 +198,7 @@ public class TestBugFixes extends BaseTestQuery {
             + " from cp.`employee.json` emp\n"
             + " group by gender";
     final String[] expectedPlans1 = {
-            ".*Agg\\(group=\\[\\{0\\}\\], agg#0=\\[\\$SUM0\\(\\$2\\)\\], agg#1=\\[\\$SUM0\\(\\$1\\)\\], agg#2=\\[COUNT\\(\\$1\\)\\]\\)",
+            ".*Agg\\(group=\\[\\{0\\}\\], cnt=\\[\\$SUM0\\(\\$2\\)\\], agg#1=\\[\\$SUM0\\(\\$1\\)\\], agg#2=\\[COUNT\\(\\$1\\)\\]\\)",
             ".*Agg\\(group=\\[\\{0, 1\\}\\], cnt=\\[COUNT\\(\\)\\]\\)"};
     final String[] excludedPlans1 = {".*Join\\(condition=\\[true\\], joinType=\\[inner\\]\\).*"};
     PlanTestBase.testPlanMatchingPatterns(query1, expectedPlans1, excludedPlans1);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestWindowFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestWindowFunctions.java
@@ -907,7 +907,7 @@ public class TestWindowFunctions extends BaseTestQuery {
           + " window w1 as (partition by l_suppkey)";
       test(query);
     } catch(UserException ex) {
-      assert(ex.getMessage().contains("Expression 'tpch/nation.parquet.l_suppkey' is not being grouped"));
+      assert(ex.getMessage().contains("Expression 'l_suppkey' is not being grouped"));
     }
 
     try {
@@ -932,7 +932,7 @@ public class TestWindowFunctions extends BaseTestQuery {
           + " window w2 as (partition by n_nationkey)";
       test(query);
     } catch(UserException ex) {
-      assert(ex.getMessage().contains("Expression 'tpch/nation.parquet.n_nationkey' is not being grouped"));
+      assert(ex.getMessage().contains("Expression 'n_nationkey' is not being grouped"));
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dep.guava.version>18.0</dep.guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.8.1-drill-r0</parquet.version>
-    <calcite.version>1.13.0-drill-r0</calcite.version>
+    <calcite.version>1.15.0-drill-r0</calcite.version>
     <avatica.version>1.10.0</avatica.version>
     <janino.version>2.7.6</janino.version>
     <sqlline.version>1.1.9-drill-r7</sqlline.version>


### PR DESCRIPTION
Fix AssertionError: type mismatch for tests with aggregate functions.
Fix VARIANCE agg function
Remove using deprecated Subtype enum
Fix 'Failure while loading table a in database hbase' error
Fix 'Field ordinal 1 is invalid for  type '(DrillRecordRow[*])'' unit test failures